### PR TITLE
Return source definition for MCP lookup

### DIFF
--- a/tests/lookup_module.hy
+++ b/tests/lookup_module.hy
@@ -1,0 +1,3 @@
+(defn lookup-target [x]
+  "Sample function for lookup tests."
+  (+ x 1))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,6 +30,26 @@ def test_nrepl_lookup_basic():
         thread.join(timeout=1)
 
 
+def test_nrepl_lookup_returns_definition():
+    mcp_server.NREPL_SESSION = None  # Ensure clean state before test
+    thread, srv = start_server("127.0.0.1", 0)
+    host, port = srv.server_address
+    try:
+        nrepl_eval(
+            "(import tests.lookup-module [lookup-target])",
+            host=host,
+            port=port,
+        )
+        info = nrepl_lookup("lookup-target", host=host, port=port)
+        assert info.get("name") == "lookup-target"
+        assert "definition" in info
+        assert "lookup-target" in info["definition"]
+    finally:
+        mcp_server.NREPL_SESSION = None  # Clean up after test
+        srv.shutdown()
+        thread.join(timeout=1)
+
+
 def test_nrepl_eval_session_persistence():
     mcp_server.NREPL_SESSION = None  # Ensure clean state before test
     thread, srv = start_server("127.0.0.1", 0)


### PR DESCRIPTION
## Summary
- expose source snippet from `lookup` MCP tool
- test fetching definition and returning it to the LLM

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8847deed483269e0713f72625ad9d